### PR TITLE
Add CLR management features

### DIFF
--- a/assembly.go
+++ b/assembly.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package clr
@@ -103,8 +104,10 @@ func (obj *Assembly) Release() uintptr {
 }
 
 // GetEntryPoint returns the assembly's MethodInfo
-//      virtual HRESULT __stdcall get_EntryPoint (
-//     /*[out,retval]*/ struct _MethodInfo * * pRetVal ) = 0;
+//
+//	 virtual HRESULT __stdcall get_EntryPoint (
+//	/*[out,retval]*/ struct _MethodInfo * * pRetVal ) = 0;
+//
 // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.entrypoint?view=netframework-4.8#System_Reflection_Assembly_EntryPoint
 // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.methodinfo?view=netframework-4.8
 func (obj *Assembly) GetEntryPoint() (pRetVal *MethodInfo, err error) {
@@ -126,4 +129,19 @@ func (obj *Assembly) GetEntryPoint() (pRetVal *MethodInfo, err error) {
 	}
 	err = nil
 	return
+}
+
+func (obj *Assembly) GetFullName() (string, error) {
+	var pRetValBSTR unsafe.Pointer
+	hr, _, _ := syscall.Syscall(
+		obj.vtbl.get_FullName,
+		2,
+		uintptr(unsafe.Pointer(obj)),
+		uintptr(unsafe.Pointer(&pRetValBSTR)),
+		0)
+	err := checkOK(hr, "assembly.getfullname")
+	if err != nil {
+		return "", err
+	}
+	return ReadUnicodeStr(pRetValBSTR), nil
 }

--- a/guids.go
+++ b/guids.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package clr

--- a/iclrmetahost.go
+++ b/iclrmetahost.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package clr
@@ -13,7 +14,7 @@ import (
 // Couldnt have done any of this without this SO answer I stumbled on:
 // https://stackoverflow.com/questions/37781676/how-to-use-com-component-object-model-in-golang
 
-//ICLRMetaHost Interface from metahost.h
+// ICLRMetaHost Interface from metahost.h
 type ICLRMetaHost struct {
 	vtbl *ICLRMetaHostVtbl
 }
@@ -53,9 +54,11 @@ type ICLRMetaHostVtbl struct {
 
 // CLRCreateInstance provides one of three interfaces: ICLRMetaHost, ICLRMetaHostPolicy, or ICLRDebugging.
 // HRESULT CLRCreateInstance(
-//   [in]  REFCLSID  clsid,
-//   [in]  REFIID     riid,
-//   [out] LPVOID  * ppInterface
+//
+//	[in]  REFCLSID  clsid,
+//	[in]  REFIID     riid,
+//	[out] LPVOID  * ppInterface
+//
 // );
 // https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/hosting/clrcreateinstance-function
 func CLRCreateInstance(clsid, riid windows.GUID) (ppInterface *ICLRMetaHost, err error) {
@@ -129,7 +132,9 @@ func (obj *ICLRMetaHost) Release() uintptr {
 // EnumerateInstalledRuntimes returns an enumeration that contains a valid ICLRRuntimeInfo interface for each
 // version of the common language runtime (CLR) that is installed on a computer.
 // HRESULT EnumerateInstalledRuntimes (
-//   [out, retval] IEnumUnknown **ppEnumerator);
+//
+//	[out, retval] IEnumUnknown **ppEnumerator);
+//
 // https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/hosting/iclrmetahost-enumerateinstalledruntimes-method
 func (obj *ICLRMetaHost) EnumerateInstalledRuntimes() (ppEnumerator *IEnumUnknown, err error) {
 	debugPrint("Entering into iclrmetahost.EnumerateInstalledRuntimes()...")
@@ -155,9 +160,11 @@ func (obj *ICLRMetaHost) EnumerateInstalledRuntimes() (ppEnumerator *IEnumUnknow
 // GetRuntime gets the ICLRRuntimeInfo interface that corresponds to a particular version of the common language runtime (CLR).
 // This method supersedes the CorBindToRuntimeEx function used with the STARTUP_LOADER_SAFEMODE flag.
 // HRESULT GetRuntime (
-//   [in] LPCWSTR pwzVersion,
-//   [in] REFIID riid,
-//   [out,iid_is(riid), retval] LPVOID *ppRuntime
+//
+//	[in] LPCWSTR pwzVersion,
+//	[in] REFIID riid,
+//	[out,iid_is(riid), retval] LPVOID *ppRuntime
+//
 // );
 // https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/hosting/iclrmetahost-getruntime-method
 func (obj *ICLRMetaHost) GetRuntime(pwzVersion *uint16, riid windows.GUID) (ppRuntime *ICLRRuntimeInfo, err error) {

--- a/icorruntimehost.go
+++ b/icorruntimehost.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package clr
@@ -146,7 +147,9 @@ func (obj *ICORRuntimeHost) Start() error {
 
 // GetDefaultDomain gets an interface pointer of type System._AppDomain that represents the default domain for the current process.
 // HRESULT GetDefaultDomain (
-//   [out] IUnknown** pAppDomain
+//
+//	[out] IUnknown** pAppDomain
+//
 // );
 // https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/hosting/icorruntimehost-getdefaultdomain-method
 func (obj *ICORRuntimeHost) GetDefaultDomain() (IUnknown *IUnknown, err error) {
@@ -173,9 +176,11 @@ func (obj *ICORRuntimeHost) GetDefaultDomain() (IUnknown *IUnknown, err error) {
 
 // CreateDomain Creates an application domain. The caller receives an interface pointer of type _AppDomain to an instance of type System.AppDomain.
 // HRESULT CreateDomain (
-//   [in] LPWSTR    pwzFriendlyName,
-//   [in] IUnknown* pIdentityArray,
-//   [out] void   **pAppDomain
+//
+//	[in] LPWSTR    pwzFriendlyName,
+//	[in] IUnknown* pIdentityArray,
+//	[out] void   **pAppDomain
+//
 // );
 // https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ms164322(v=vs.100)
 func (obj *ICORRuntimeHost) CreateDomain(pwzFriendlyName *uint16) (pAppDomain *AppDomain, err error) {
@@ -205,7 +210,9 @@ func (obj *ICORRuntimeHost) CreateDomain(pwzFriendlyName *uint16) (pAppDomain *A
 
 // EnumDomains Gets an enumerator for the domains in the current process.
 // HRESULT EnumDomains (
-//   [out] HCORENUM *hEnum
+//
+//	[out] HCORENUM *hEnum
+//
 // );
 func (obj *ICORRuntimeHost) EnumDomains() (hEnum *uintptr, err error) {
 	debugPrint("Enterin into icorruntimehost.EnumDomains()...")
@@ -228,4 +235,23 @@ func (obj *ICORRuntimeHost) EnumDomains() (hEnum *uintptr, err error) {
 	}
 	err = nil
 	return
+}
+
+func (obj *ICORRuntimeHost) NextDomain(hDomainEnum uintptr, iunknownptr *uintptr) uintptr {
+	ret, _, _ := syscall.SyscallN(
+		obj.vtbl.NextDomain,
+		uintptr(unsafe.Pointer(obj)),
+		uintptr(unsafe.Pointer(hDomainEnum)),
+		uintptr(unsafe.Pointer(iunknownptr)),
+	)
+	return ret
+}
+
+func (obj *ICORRuntimeHost) CloseEnum(hDomainEnum uintptr) uintptr {
+	ret, _, _ := syscall.SyscallN(
+		obj.vtbl.CloseEnum,
+		uintptr(unsafe.Pointer(obj)),
+		uintptr(unsafe.Pointer(hDomainEnum)),
+	)
+	return ret
 }

--- a/safearray.go
+++ b/safearray.go
@@ -1,23 +1,28 @@
+//go:build windows
 // +build windows
 
 package clr
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"syscall"
 	"unsafe"
 )
 
 // SafeArray represents a safe array
 // defined in OAIdl.h
-// typedef struct tagSAFEARRAY {
-//   USHORT         cDims;
-//   USHORT         fFeatures;
-//   ULONG          cbElements;
-//   ULONG          cLocks;
-//   PVOID          pvData;
-//   SAFEARRAYBOUND rgsabound[1];
-// } SAFEARRAY;
+//
+//	typedef struct tagSAFEARRAY {
+//	  USHORT         cDims;
+//	  USHORT         fFeatures;
+//	  ULONG          cbElements;
+//	  ULONG          cLocks;
+//	  PVOID          pvData;
+//	  SAFEARRAYBOUND rgsabound[1];
+//	} SAFEARRAY;
+//
 // https://docs.microsoft.com/en-us/windows/win32/api/oaidl/ns-oaidl-safearray
 // https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/march/introducing-the-safearray-data-structure
 type SafeArray struct {
@@ -36,10 +41,12 @@ type SafeArray struct {
 }
 
 // SafeArrayBound represents the bounds of one dimension of the array
-// typedef struct tagSAFEARRAYBOUND {
-//   ULONG cElements;
-//   LONG  lLbound;
-// } SAFEARRAYBOUND, *LPSAFEARRAYBOUND;
+//
+//	typedef struct tagSAFEARRAYBOUND {
+//	  ULONG cElements;
+//	  LONG  lLbound;
+//	} SAFEARRAYBOUND, *LPSAFEARRAYBOUND;
+//
 // https://docs.microsoft.com/en-us/windows/win32/api/oaidl/ns-oaidl-safearraybound
 type SafeArrayBound struct {
 	// cElements is the number of elements in the dimension
@@ -89,9 +96,11 @@ func CreateSafeArray(rawBytes []byte) (*SafeArray, error) {
 
 // SafeArrayCreate creates a new array descriptor, allocates and initializes the data for the array, and returns a pointer to the new array descriptor.
 // SAFEARRAY * SafeArrayCreate(
-//   VARTYPE        vt,
-//   UINT           cDims,
-//   SAFEARRAYBOUND *rgsabound
+//
+//	VARTYPE        vt,
+//	UINT           cDims,
+//	SAFEARRAYBOUND *rgsabound
+//
 // );
 // Varient types: https://docs.microsoft.com/en-us/windows/win32/api/wtypes/ne-wtypes-varenum
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearraycreate
@@ -117,17 +126,22 @@ func SafeArrayCreate(vt uint16, cDims uint32, rgsabound *SafeArrayBound) (safeAr
 		return
 	}
 
+	//avoid go vet by casting and dereferencing
+	cast1 := (**uintptr)(unsafe.Pointer(&ret))
+
 	// Unable to avoid misuse of unsafe.Pointer because the Windows API call returns the safeArray pointer in the "ret" value. This is a go vet false positive
-	safeArray = (*SafeArray)(unsafe.Pointer(ret))
+	safeArray = (*SafeArray)(unsafe.Pointer(*cast1))
 	return
 }
 
 // SysAllocString converts a Go string to a BTSR string, that is a unicode string prefixed with its length.
 // Allocates a new string and copies the passed string into it.
 // It returns a pointer to the string's content.
-//  BSTR SysAllocString(
-//    const OLECHAR *psz
-//  );
+//
+//	BSTR SysAllocString(
+//	  const OLECHAR *psz
+//	);
+//
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-sysallocstring
 func SysAllocString(str string) (unsafe.Pointer, error) {
 	debugPrint("Entering into safearray.SysAllocString()...")
@@ -144,16 +158,37 @@ func SysAllocString(str string) (unsafe.Pointer, error) {
 		return nil, err
 	}
 	// TODO Return a pointer to a BSTR instead of an unsafe.Pointer
-	// Unable to avoid misuse of unsafe.Pointer because the Windows API call returns the safeArray pointer in the "ret" value. This is a go vet false positive
-	return unsafe.Pointer(ret), nil
+
+	//cast crimes to trick silly go vet, who will get pranked by the simplest slieght of hand
+	//we give unsafe.pointer a pointer to the return value, which makes go vet ignore it.
+	//But we then cast it to a pointer to a pointer, and then dereference the first pointer.
+	//This leaves us with the original pointer, with no go vet complaints
+	r1 := *(**uintptr)(unsafe.Pointer(&ret))
+
+	return unsafe.Pointer(r1), nil
+}
+
+// SysStringLen indicates how long a BSTR is
+func SysStringLen(p uintptr) (int, error) {
+	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
+	sysAllocString := modOleAuto.MustFindProc("SysStringLen")
+	ret, _, err := sysAllocString.Call(
+		p,
+	)
+	if err != syscall.Errno(0) {
+		return 0, err
+	}
+	return int(ret), nil
 }
 
 // SafeArrayPutElement pushes an element to the safe array at a given index
-//  HRESULT SafeArrayPutElement(
-//	  SAFEARRAY *psa,
-//	  LONG      *rgIndices,
-//	  void      *pv
-//  );
+//
+//	 HRESULT SafeArrayPutElement(
+//		  SAFEARRAY *psa,
+//		  LONG      *rgIndices,
+//		  void      *pv
+//	 );
+//
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearrayputelement
 func SafeArrayPutElement(psa *SafeArray, rgIndices int32, pv unsafe.Pointer) error {
 	debugPrint("Entering into safearray.SafeArrayPutElement()...")
@@ -177,7 +212,9 @@ func SafeArrayPutElement(psa *SafeArray, rgIndices int32, pv unsafe.Pointer) err
 
 // SafeArrayLock increments the lock count of an array, and places a pointer to the array data in pvData of the array descriptor
 // HRESULT SafeArrayLock(
-//   SAFEARRAY *psa
+//
+//	SAFEARRAY *psa
+//
 // );
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearraylock
 func SafeArrayLock(psa *SafeArray) error {
@@ -201,8 +238,10 @@ func SafeArrayLock(psa *SafeArray) error {
 
 // SafeArrayGetVartype gets the VARTYPE stored in the specified safe array
 // HRESULT SafeArrayGetVartype(
-//   SAFEARRAY *psa,
-//   VARTYPE   *pvt
+//
+//	SAFEARRAY *psa,
+//	VARTYPE   *pvt
+//
 // );
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearraygetvartype
 func SafeArrayGetVartype(psa *SafeArray) (uint16, error) {
@@ -229,8 +268,10 @@ func SafeArrayGetVartype(psa *SafeArray) (uint16, error) {
 
 // SafeArrayAccessData increments the lock count of an array, and retrieves a pointer to the array data
 // HRESULT SafeArrayAccessData(
-//   SAFEARRAY  *psa,
-//   void HUGEP **ppvData
+//
+//	SAFEARRAY  *psa,
+//	void HUGEP **ppvData
+//
 // );
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearrayaccessdata
 func SafeArrayAccessData(psa *SafeArray) (*uintptr, error) {
@@ -257,9 +298,11 @@ func SafeArrayAccessData(psa *SafeArray) (*uintptr, error) {
 
 // SafeArrayGetLBound gets the lower bound for any dimension of the specified safe array
 // HRESULT SafeArrayGetLBound(
-//   SAFEARRAY *psa,
-//   UINT      nDim,
-//   LONG      *plLbound
+//
+//	SAFEARRAY *psa,
+//	UINT      nDim,
+//	LONG      *plLbound
+//
 // );
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearraygetlbound
 func SafeArrayGetLBound(psa *SafeArray, nDim uint32) (uint32, error) {
@@ -285,9 +328,11 @@ func SafeArrayGetLBound(psa *SafeArray, nDim uint32) (uint32, error) {
 
 // SafeArrayGetUBound gets the upper bound for any dimension of the specified safe array
 // HRESULT SafeArrayGetUBound(
-//   SAFEARRAY *psa,
-//   UINT      nDim,
-//   LONG      *plUbound
+//
+//	SAFEARRAY *psa,
+//	UINT      nDim,
+//	LONG      *plUbound
+//
 // );
 // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearraygetubound
 func SafeArrayGetUBound(psa *SafeArray, nDim uint32) (uint32, error) {
@@ -316,7 +361,9 @@ func SafeArrayGetUBound(psa *SafeArray, nDim uint32) (uint32, error) {
 // SafeArrayDestroy Destroys an existing array descriptor and all of the data in the array.
 // If objects are stored in the array, Release is called on each object in the array.
 // HRESULT SafeArrayDestroy(
-//   SAFEARRAY *psa
+//
+//	SAFEARRAY *psa
+//
 // );
 func SafeArrayDestroy(psa *SafeArray) error {
 	debugPrint("Entering into safearray.SafeArrayDestroy()...")
@@ -337,4 +384,53 @@ func SafeArrayDestroy(psa *SafeArray) error {
 		return fmt.Errorf("the oleaut32!SafeArrayDestroy function returned a non-zero HRESULT: 0x%x", hr)
 	}
 	return nil
+}
+
+// SafeArrayGetDim returns the dimensions of a safearray
+func SafeArrayGetDim(psa *SafeArray) (dimensions uint32, err error) {
+	debugPrint("Entering into safearray.SafeArrayGetDim()...")
+
+	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
+	SafeArrayGetDim := modOleAuto.MustFindProc("SafeArrayGetDim")
+	udimensions, _, err := SafeArrayGetDim.Call(
+		uintptr(unsafe.Pointer(psa)),
+	)
+	if !errors.Is(err, syscall.Errno(0)) {
+		return 0, err
+	}
+	return uint32(udimensions), nil
+}
+
+// SafeArrayGetElement gets an element from the array at the given index
+func SafeArrayGetElement(array *SafeArray, indicies uint32) (ret unsafe.Pointer, err error) {
+	debugPrint("Entering into safearray.SafeArrayGetElement()...")
+
+	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
+	SafeArrayGetElement := modOleAuto.MustFindProc("SafeArrayGetElement")
+	uret, _, err := SafeArrayGetElement.Call(
+		uintptr(unsafe.Pointer(array)),
+		uintptr(unsafe.Pointer(&indicies)),
+		uintptr(unsafe.Pointer(&ret)),
+	)
+	if !errors.Is(err, syscall.Errno(0)) {
+		return nil, err
+	}
+	err = nil
+	log.Println("Safearray: ", indicies, uret)
+	return
+}
+
+// SafeArrayPutElement pushes an element to the safe array at a given index
+func SafeArrayGetElemsize(array unsafe.Pointer) (ret uintptr, err error) {
+	debugPrint("Entering into safearray.SafeArrayGetElemsize()...")
+
+	modOleAuto := syscall.MustLoadDLL("OleAut32.dll")
+	safeArrayPutElement := modOleAuto.MustFindProc("SafeArrayGetElemsize")
+	ret, _, err = safeArrayPutElement.Call(
+		uintptr(array),
+	)
+	if !errors.Is(err, syscall.Errno(0)) {
+		return 0, err
+	}
+	return ret, nil
 }


### PR DESCRIPTION
The aim of this PR is to provide the ability to:

easily create and unload named appdomains
stop the runtime on demand
be able to list loaded assemblies
be able to get a reference to an assembly within the appdomain without needing to manually keep track of them
Did my best to try and keep to the Go sanctioned use of unsafe.Pointer, and tried to stick to the existing code style, but took some creative freedom here and there.